### PR TITLE
docs: migrate AI references to GitHub Copilot and rename scripts/ai to scripts/automation

### DIFF
--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -55,9 +55,9 @@ repo-template-public/
 │  ├─ architecture.md             # Mermaid diagram of CI/PR/changelog flow
 │  └─ api/auto.md                 # optional AI‑generated docs
 ├─ scripts/
-│  ├─ ai/
-│  │  ├─ changelog_check.mjs      # PR body validator + AI suggestions
-│  │  └─ changelog_generate.mjs   # draft release notes from commits
+│  ├─ automation/
+│  │  ├─ changelog_check.mjs      # PR body validator + (future) suggestion hook
+│  │  └─ changelog_generate.mjs   # draft release notes from commits (planned)
 │  ├─ metrics/
 │  │  └─ log_build.mjs            # optional telemetry demo
 │  └─ release/
@@ -73,7 +73,7 @@ repo-template-public/
 
 - Node 20+ and pnpm 9+ (or switch to npm/yarn)
 - A GitHub repository (public). Default branch: main.
-- Optional: OPENAI_API_KEY as a repository secret to enable AI features.
+- Optional: Enable GitHub Copilot for your user/org (provides in‑editor suggestions, PR summaries, and release note drafting assistance inside GitHub).
 
 Install tools locally:
 
@@ -96,9 +96,9 @@ pnpm -v   # should print v9.x
    ```
 
 3. Add the files from this guide (or copy from the canvas kit). Commit and push.
-4. In GitHub → Settings → Actions → Secrets and variables → Actions:
+4. In GitHub → Repository Settings → GitHub Copilot:
 
-   - Add OPENAI_API_KEY (optional; enables AI‑assisted steps).
+   - Ensure Copilot is enabled for this repository (if your org requires per‑repo enablement).
 
 5. Enable security:
 
@@ -132,7 +132,7 @@ node dist/index.js
 ### Pull Requests
 
 - Always use the PR template and fill the ## Changelog block.
-- The PR guard fails PRs that omit the block; with OPENAI_API_KEY set, it prints suggested text.
+- The PR guard (if present) enforces the block. For suggested wording, use GitHub Copilot Chat or the PR "Generate summary" feature (where available) and adapt the output to Keep a Changelog categories.
 - Keep PRs small and focused; include screenshots when relevant.
 
 ---
@@ -149,14 +149,14 @@ node dist/index.js
 
 - Triggers on PR open/edit/sync.
 - Reads the PR body; fails if missing ## Changelog.
-- If OPENAI_API_KEY exists, calls the OpenAI API to generate a concise changelog suggestion, printed in the logs.
+- (Optional future enhancement) A lightweight script could add a PR comment reminding authors of format. Copilot can assist manually via the PR UI; no external API key required.
 
-### 6.3 ai-changelog.yml
+### 6.3 changelog-draft.yml (future optional)
 
-- Triggers on push to main|master|release/\*\* and via manual dispatch.
-- Gathers commits since last tag (if any).
-- With OPENAI_API_KEY, drafts a Keep‑a‑Changelog entry and opens a PR updating CHANGELOG.md.
-- Without a key, writes a placeholder entry.
+- (Planned) On push to main|master|release/\*\* and/or manual dispatch.
+- Gathers commits since last tag (if any) and assembles a draft Keep‑a‑Changelog section.
+- Maintainers can refine the draft using GitHub Copilot Chat (ask Copilot to summarise commit messages into categories) before committing.
+- No third‑party API keys required; relies on local summarisation via Copilot in the editor or PR UI rather than an Action calling external LLM APIs.
 
 ### 6.4 Security workflows
 
@@ -165,9 +165,7 @@ node dist/index.js
 
 Environment variables used in workflows
 
-- OPENAI_API_KEY (secret) - enables AI features
-- OPENAI_MODEL (secret/variable) - defaults to gpt-4o-mini
-- GITHUB_TOKEN - default token for creating PRs
+- GITHUB_TOKEN — default token for creating PRs (auto-provided). No extra AI secrets needed for Copilot.
 
 ---
 
@@ -176,8 +174,8 @@ Environment variables used in workflows
 We follow Keep a Changelog and SemVer. See CHANGELOG_GUIDE.md for category definitions and examples.
 
 - Every PR must include a ## Changelog section in the body.
-- The PR guard enforces presence and optionally suggests text.
-- On merge to main, the AI changelog workflow drafts entries and opens a PR for human review.
+- The PR guard (or reviewer) enforces presence; for help drafting concise entries, use Copilot Chat (e.g., "Summarise this diff into Keep a Changelog Added/Changed/Fixed bullets").
+- After merge, you can run (or later add) a draft changelog workflow; refine the result using Copilot before publishing.
 
 ### Examples
 
@@ -227,7 +225,7 @@ We follow Keep a Changelog and SemVer. See CHANGELOG_GUIDE.md for category defin
 
 - Start with manual tagging for v0.1.0 after the first public milestone.
 - Integrate Changesets or semantic‑release later for automatic semver bumps.
-- The AI changelog workflow focuses on notes, not version numbers; pair it with your chosen versioning tool.
+- (Optional) Use Copilot Chat to help refine release notes or categorize changes once a tag is prepared.
 
 Manual release checklist
 
@@ -245,10 +243,10 @@ Manual release checklist
 - SBOM generation (CycloneDX) and license scan
 - Preview deploy on develop; release on main
 
-### Phase 3 - AI enhancements
+### Phase 3 - Copilot enhancements
 
-- PR AI summariser that comments key changes and risk
-- AI issue triage that proposes labels/size/areas
+- Leverage GitHub Copilot PR summaries (when enabled) to auto-suggest changelog bullets.
+- Use Copilot Chat to propose labels / scope tags by prompting with issue body content.
 
 ### Phase 4 - DX polish
 
@@ -270,7 +268,7 @@ Manual release checklist
 
 ## 14. Troubleshooting
 
-- PR guard fails: Ensure the PR body contains a ## Changelog section. If AI suggestions don’t appear, check the OPENAI_API_KEY secret.
+- PR guard fails: Ensure the PR body contains a ## Changelog section. For suggested text, invoke Copilot Chat or use PR summary generation.
 - ai‑changelog doesn’t open a PR: Ensure the workflow has contents: write permissions and the default GITHUB_TOKEN is available. Also check that fetch-depth: 0 is set for actions/checkout.
 - CI step keeps passing even with problems: Some steps are initially non‑blocking (|| true). Remove those once linters/tests are configured.
 - CodeQL not scanning: Go to Security → Code scanning alerts → “Set up” and ensure the workflow is enabled on main.

--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -114,7 +114,7 @@ pnpm -v   # should print v9.x
 ### Branching
 
 - Default branch: main
-- Feature branches: type/short-desc (e.g., feat/ai-changelog) using Conventional Commits in commit messages.
+- Feature branches: type/short-desc (e.g., feat/automation-changelog) using Conventional Commits in commit messages.
 
 ### Commit messages (Conventional Commits)
 

--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -269,7 +269,7 @@ Manual release checklist
 ## 14. Troubleshooting
 
 - PR guard fails: Ensure the PR body contains a ## Changelog section. For suggested text, invoke Copilot Chat or use PR summary generation.
-- ai‑changelog doesn’t open a PR: Ensure the workflow has contents: write permissions and the default GITHUB_TOKEN is available. Also check that fetch-depth: 0 is set for actions/checkout.
+- AI changelog workflow doesn’t open a PR: Ensure the workflow has contents: write permissions and the default GITHUB_TOKEN is available. Also check that fetch-depth: 0 is set for actions/checkout. If using Copilot-based automation, verify Copilot permissions and configuration.
 - CI step keeps passing even with problems: Some steps are initially non‑blocking (|| true). Remove those once linters/tests are configured.
 - CodeQL not scanning: Go to Security → Code scanning alerts → “Set up” and ensure the workflow is enabled on main.
 

--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -262,7 +262,7 @@ Manual release checklist
 2. Write small, focused commits with Conventional Commits.
 3. Open a PR using the template; fill ## Changelog clearly.
 4. Wait for green CI + PR guard; request review.
-5. After merge, review the AI changelog PR and finalize notes.
+5. After merge, review and finalize the changelog notes (use Copilot PR summary or chat as needed).
 
 ---
 

--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -1,27 +1,30 @@
-PROJECT_GUIDE.md — repo-template-public
+# PROJECT_GUIDE.md - repo-template-public
 
-A complete, copy‑ready guide for contributors and maintainers of repo‑template‑public. This describes the why, what, and how so anyone can stand up the template from an empty GitHub repository and extend it with confidence.
+A complete, copy‑ready guide for contributors and maintainers of repo‑template-public. This describes the why, what, and how so anyone can stand up the template from an empty GitHub repository and extend it with confidence.
 
 TL;DR: This template bakes in DevOps hygiene (CI, security, changelogs), Conventional Commits, and optional AI assistance for PRs and release notes. It’s intentionally lightweight so you can adapt it to any Node/TypeScript project.
 
-⸻
+---
 
-1) Goals & Non‑Goals
+## 1. Goals & Non‑Goals
 
-Goals
-	•	Provide a professional public starter for Node/TypeScript projects.
-	•	Make automation visible: CI, CodeQL, Dependabot, PR checks, changelog flows.
-	•	Encourage small, well‑documented changes via PR templates and Conventional Commits.
-	•	Offer AI assistance (optional) for PR changelog text and release note drafting.
+### Goals
 
-Non‑Goals
-	•	This is not a framework; it’s a starter. Swap any tool (pnpm → npm, TS → JS) as needed.
-	•	Not a monorepo by default; you can promote it later into a standards monorepo.
+- Provide a professional public starter for Node/TypeScript projects.
+- Make automation visible: CI, CodeQL, Dependabot, PR checks, changelog flows.
+- Encourage small, well‑documented changes via PR templates and Conventional Commits.
+- Offer AI assistance (optional) for PR changelog text and release note drafting.
 
-⸻
+### Non‑Goals
 
-2) Repository Layout
+- This is not a framework; it’s a starter. Swap any tool (pnpm → npm, TS → JS) as needed.
+- Not a monorepo by default; you can promote it later into a standards monorepo.
 
+---
+
+## 2. Repository Layout
+
+```text
 repo-template-public/
 ├─ .github/
 │  ├─ ISSUE_TEMPLATE/
@@ -60,193 +63,228 @@ repo-template-public/
 │  └─ release/
 │     └─ prepare_release.mjs      # optional version hook
 └─ src/
-   ├─ index.ts
-   └─ index.test.ts               # placeholder; swap for Vitest later
+    ├─ index.ts
+    └─ index.test.ts               # placeholder; swap for Vitest later
+```
 
+---
 
-⸻
+## 3. Prerequisites
 
-3) Prerequisites
-	•	Node 20+ and pnpm 9+ (or switch to npm/yarn)
-	•	A GitHub repository (public). Default branch: main.
-	•	Optional: OPENAI_API_KEY as a repository secret to enable AI features.
+- Node 20+ and pnpm 9+ (or switch to npm/yarn)
+- A GitHub repository (public). Default branch: main.
+- Optional: OPENAI_API_KEY as a repository secret to enable AI features.
 
 Install tools locally:
 
+```sh
 corepack enable && corepack prepare pnpm@latest --activate
 pnpm -v   # should print v9.x
+```
 
+---
 
-⸻
+## 4. Quickstart (from an empty repo)
 
-4) Quickstart (from an empty repo)
-	1.	Create a new repo on GitHub named repo-template-public and clone it locally.
-	2.	Initialise the workspace:
+1. Create a new repo on GitHub named repo-template-public and clone it locally.
+2. Initialise the workspace:
 
-pnpm init -y
-pnpm add -D typescript @commitlint/cli @commitlint/config-conventional
-pnpm tsc --init
+   ```sh
+   pnpm init -y
+   pnpm add -D typescript @commitlint/cli @commitlint/config-conventional
+   pnpm tsc --init
+   ```
 
+3. Add the files from this guide (or copy from the canvas kit). Commit and push.
+4. In GitHub → Settings → Actions → Secrets and variables → Actions:
 
-	3.	Add the files from this guide (or copy from the canvas kit). Commit and push.
-	4.	In GitHub → Settings → Actions → Secrets and variables → Actions:
-	•	Add OPENAI_API_KEY (optional; enables AI‑assisted steps).
-	5.	Enable security:
-	•	Code scanning (CodeQL) → Enable for default branch
-	•	Dependabot alerts → On
-	6.	Open a test PR to see CI and PR changelog guard in action.
+   - Add OPENAI_API_KEY (optional; enables AI‑assisted steps).
 
-⸻
+5. Enable security:
 
-5) Development Workflow
+   - Code scanning (CodeQL) → Enable for default branch
+   - Dependabot alerts → On
 
-Branching
-	•	Default branch: main
-	•	Feature branches: type/short-desc (e.g., feat/ai-changelog) using Conventional Commits in commit messages.
+6. Open a test PR to see CI and PR changelog guard in action.
 
-Commit messages (Conventional Commits)
-	•	Types: feat, fix, docs, refactor, test, chore, perf, ci
-	•	Examples: feat(api): add CSV import, fix(auth): handle expired tokens
+---
 
-Local scripts
+## 5. Development Workflow
 
+### Branching
+
+- Default branch: main
+- Feature branches: type/short-desc (e.g., feat/ai-changelog) using Conventional Commits in commit messages.
+
+### Commit messages (Conventional Commits)
+
+- Types: feat, fix, docs, refactor, test, chore, perf, ci
+- Examples: feat(api): add CSV import, fix(auth): handle expired tokens
+
+### Local scripts
+
+```sh
 pnpm verify   # lint + typecheck + test
 pnpm build    # compiles to dist/
 node dist/index.js
+```
 
-Pull Requests
-	•	Always use the PR template and fill the ## Changelog block.
-	•	The PR guard fails PRs that omit the block; with OPENAI_API_KEY set, it prints suggested text.
-	•	Keep PRs small and focused; include screenshots when relevant.
+### Pull Requests
 
-⸻
+- Always use the PR template and fill the ## Changelog block.
+- The PR guard fails PRs that omit the block; with OPENAI_API_KEY set, it prints suggested text.
+- Keep PRs small and focused; include screenshots when relevant.
 
-6) CI/CD Overview
+---
 
-6.1 ci.yml
-	•	Triggers on PR and push to main|master.
-	•	Steps: Checkout → pnpm setup → install → lint → typecheck → test → build.
-	•	Some steps are non‑blocking (|| true) until you add real lint/tests; convert them to blocking as the project matures.
+## 6. CI/CD Overview
 
-6.2 pr-changelog-guard.yml
-	•	Triggers on PR open/edit/sync.
-	•	Reads the PR body; fails if missing ## Changelog.
-	•	If OPENAI_API_KEY exists, calls the OpenAI API to generate a concise changelog suggestion, printed in the logs.
+### 6.1 ci.yml
 
-6.3 ai-changelog.yml
-	•	Triggers on push to main|master|release/** and via manual dispatch.
-	•	Gathers commits since last tag (if any).
-	•	With OPENAI_API_KEY, drafts a Keep‑a‑Changelog entry and opens a PR updating CHANGELOG.md.
-	•	Without a key, writes a placeholder entry.
+- Triggers on PR and push to main|master.
+- Steps: Checkout → pnpm setup → install → lint → typecheck → test → build.
+- Some steps are non‑blocking (|| true) until you add real lint/tests; convert them to blocking as the project matures.
 
-6.4 Security workflows
-	•	CodeQL runs on PR and weekly schedule.
-	•	Dependabot opens weekly npm update PRs.
+### 6.2 pr-changelog-guard.yml
+
+- Triggers on PR open/edit/sync.
+- Reads the PR body; fails if missing ## Changelog.
+- If OPENAI_API_KEY exists, calls the OpenAI API to generate a concise changelog suggestion, printed in the logs.
+
+### 6.3 ai-changelog.yml
+
+- Triggers on push to main|master|release/\*\* and via manual dispatch.
+- Gathers commits since last tag (if any).
+- With OPENAI_API_KEY, drafts a Keep‑a‑Changelog entry and opens a PR updating CHANGELOG.md.
+- Without a key, writes a placeholder entry.
+
+### 6.4 Security workflows
+
+- CodeQL runs on PR and weekly schedule.
+- Dependabot opens weekly npm update PRs.
 
 Environment variables used in workflows
-	•	OPENAI_API_KEY (secret) — enables AI features
-	•	OPENAI_MODEL (secret/variable) — defaults to gpt-4o-mini
-	•	GITHUB_TOKEN — default token for creating PRs
 
-⸻
+- OPENAI_API_KEY (secret) - enables AI features
+- OPENAI_MODEL (secret/variable) - defaults to gpt-4o-mini
+- GITHUB_TOKEN - default token for creating PRs
 
-7) Changelog Discipline
+---
+
+## 7. Changelog Discipline
 
 We follow Keep a Changelog and SemVer. See CHANGELOG_GUIDE.md for category definitions and examples.
-	•	Every PR must include a ## Changelog section in the body.
-	•	The PR guard enforces presence and optionally suggests text.
-	•	On merge to main, the AI changelog workflow drafts entries and opens a PR for human review.
 
-Examples
+- Every PR must include a ## Changelog section in the body.
+- The PR guard enforces presence and optionally suggests text.
+- On merge to main, the AI changelog workflow drafts entries and opens a PR for human review.
 
+### Examples
+
+```md
 ## Changelog
+
 - Added: CSV import for CommSec statements
 - Fixed: off‑by‑one error in monthly aggregation
+```
 
+```md
 ## Changelog
+
 - Breaking: renamed env `DB_URL` → `DATABASE_URL`
   - Migration: update `.env` files and CI secrets
+```
 
+---
 
-⸻
+## 8. Security & Licensing
 
-8) Security & Licensing
-	•	CodeQL scans JavaScript/TypeScript for vulnerabilities and code smells.
-	•	Dependabot checks dependency updates weekly.
-	•	Apache‑2.0 license provides a permissive license with an explicit patent grant (commonly acceptable to employers). Swap to MIT if you prefer.
-	•	Report issues via SECURITY.md (contact: me@andrewwilks.au).
+- CodeQL scans JavaScript/TypeScript for vulnerabilities and code smells.
+- Dependabot checks dependency updates weekly.
+- Apache‑2.0 license provides a permissive license with an explicit patent grant (commonly acceptable to employers). Swap to MIT if you prefer.
+- Report issues via SECURITY.md (contact: <me@andrewwilks.au>).
 
-⸻
+---
 
-9) Documentation as Code
-	•	README.md contains high‑level overview and quickstart.
-	•	PROJECT_GUIDE.md (this file) is the contributor handbook and design doc.
-	•	docs/architecture.md holds a Mermaid diagram describing the CI → PR → changelog flow.
-	•	Optional AI doc generation can write to docs/api/auto.md from comments/commits.
-	•	Consider publishing docs to GitHub Pages later via a docs workflow.
+## 9. Documentation as Code
 
-⸻
+- README.md contains high‑level overview and quickstart.
+- PROJECT_GUIDE.md (this file) is the contributor handbook and design doc.
+- docs/architecture.md holds a Mermaid diagram describing the CI → PR → changelog flow.
+- Optional AI doc generation can write to docs/api/auto.md from comments/commits.
+- Consider publishing docs to GitHub Pages later via a docs workflow.
 
-10) Observability (Optional Demo)
-	•	scripts/metrics/log_build.mjs writes a JSON line with build metadata. Hook it into CI to simulate telemetry and later push to a dashboard.
-	•	Future: expose metrics via GitHub Pages or a tiny Cloudflare Worker API for a live visual.
+---
 
-⸻
+## 10. Observability (Optional Demo)
 
-11) Releases & Versioning
-	•	Start with manual tagging for v0.1.0 after the first public milestone.
-	•	Integrate Changesets or semantic‑release later for automatic semver bumps.
-	•	The AI changelog workflow focuses on notes, not version numbers; pair it with your chosen versioning tool.
+- scripts/metrics/log_build.mjs writes a JSON line with build metadata. Hook it into CI to simulate telemetry and later push to a dashboard.
+- Future: expose metrics via GitHub Pages or a tiny Cloudflare Worker API for a live visual.
+
+---
+
+## 11. Releases & Versioning
+
+- Start with manual tagging for v0.1.0 after the first public milestone.
+- Integrate Changesets or semantic‑release later for automatic semver bumps.
+- The AI changelog workflow focuses on notes, not version numbers; pair it with your chosen versioning tool.
 
 Manual release checklist
-	1.	Ensure CHANGELOG.md has an entry for the release.
-	2.	Create a Git tag vX.Y.Z and push tags.
-	3.	Optionally create a GitHub Release with the same notes.
 
-⸻
+1. Ensure CHANGELOG.md has an entry for the release.
+2. Create a Git tag vX.Y.Z and push tags.
+3. Optionally create a GitHub Release with the same notes.
 
-12) Roadmap (suggested next phases)
+---
 
-Phase 2 — DevOps depth
-	•	Matrix builds (Node 18/20/22)
-	•	SBOM generation (CycloneDX) and license scan
-	•	Preview deploy on develop; release on main
+## 12. Roadmap (suggested next phases)
 
-Phase 3 — AI enhancements
-	•	PR AI summariser that comments key changes and risk
-	•	AI issue triage that proposes labels/size/areas
+### Phase 2 - DevOps depth
 
-Phase 4 — DX polish
-	•	Repo init wizard CLI for quick customization
-	•	Docs publishing pipeline (VitePress/Docusaurus)
-	•	GitHub Project sync automation (issues ↔ project board)
+- Matrix builds (Node 18/20/22)
+- SBOM generation (CycloneDX) and license scan
+- Preview deploy on develop; release on main
 
-⸻
+### Phase 3 - AI enhancements
 
-13) Contribution Guide (Quick)
-	1.	Pick an issue → create a branch type/short-desc.
-	2.	Write small, focused commits with Conventional Commits.
-	3.	Open a PR using the template; fill ## Changelog clearly.
-	4.	Wait for green CI + PR guard; request review.
-	5.	After merge, review the AI changelog PR and finalize notes.
+- PR AI summariser that comments key changes and risk
+- AI issue triage that proposes labels/size/areas
 
-⸻
+### Phase 4 - DX polish
 
-14) Troubleshooting
-	•	PR guard fails: Ensure the PR body contains a ## Changelog section. If AI suggestions don’t appear, check the OPENAI_API_KEY secret.
-	•	ai‑changelog doesn’t open a PR: Ensure the workflow has contents: write permissions and the default GITHUB_TOKEN is available. Also check that fetch-depth: 0 is set for actions/checkout.
-	•	CI step keeps passing even with problems: Some steps are initially non‑blocking (|| true). Remove those once linters/tests are configured.
-	•	CodeQL not scanning: Go to Security → Code scanning alerts → “Set up” and ensure the workflow is enabled on main.
+- Repo init wizard CLI for quick customization
+- Docs publishing pipeline (VitePress/Docusaurus)
+- GitHub Project sync automation (issues ↔ project board)
 
-⸻
+---
 
-15) Maintainers & Contact
-	•	Maintainer: Andrew Wilks (@AndrewWilks)
-	•	Security contact: me@andrewwilks.au
-	•	Code of Conduct: Contributor Covenant
+## 13. Contribution Guide (Quick)
 
-⸻
+1. Pick an issue → create a branch type/short-desc.
+2. Write small, focused commits with Conventional Commits.
+3. Open a PR using the template; fill ## Changelog clearly.
+4. Wait for green CI + PR guard; request review.
+5. After merge, review the AI changelog PR and finalize notes.
 
-16) License
+---
+
+## 14. Troubleshooting
+
+- PR guard fails: Ensure the PR body contains a ## Changelog section. If AI suggestions don’t appear, check the OPENAI_API_KEY secret.
+- ai‑changelog doesn’t open a PR: Ensure the workflow has contents: write permissions and the default GITHUB_TOKEN is available. Also check that fetch-depth: 0 is set for actions/checkout.
+- CI step keeps passing even with problems: Some steps are initially non‑blocking (|| true). Remove those once linters/tests are configured.
+- CodeQL not scanning: Go to Security → Code scanning alerts → “Set up” and ensure the workflow is enabled on main.
+
+---
+
+## 15. Maintainers & Contact
+
+- Maintainer: Andrew Wilks (@AndrewWilks)
+- Security contact: <me@andrewwilks.au>
+- Code of Conduct: Contributor Covenant
+
+---
+
+## 16. License
 
 This project is licensed under the Apache License 2.0. See LICENSE for details.

--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -73,7 +73,7 @@ repo-template-public/
 
 - Node 20+ and pnpm 9+ (or switch to npm/yarn)
 - A GitHub repository (public). Default branch: main.
-- Optional: Enable GitHub Copilot for your user/org (provides in‑editor suggestions, PR summaries, and release note drafting assistance inside GitHub).
+- Optional: Enable GitHub Copilot for your user/org (provides in-editor suggestions, PR summaries, and release note drafting assistance inside GitHub).
 
 Install tools locally:
 

--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -141,7 +141,7 @@ node dist/index.js
 
 ### 6.1 ci.yml
 
-- Triggers on PR and push to main|master.
+- Trigger on PR and push to main|master.
 - Steps: Checkout → pnpm setup → install → lint → typecheck → test → build.
 - Some steps are non‑blocking (|| true) until you add real lint/tests; convert them to blocking as the project matures.
 

--- a/README.md
+++ b/README.md
@@ -23,17 +23,19 @@ New here? Read the detailed design/build guide: [PROJECT_GUIDE.md](PROJECT_GUIDE
 
 ## Table of Contents
 
-- [What’s inside](#whats-inside)
-- [Quickstart](#quickstart)
-- [Scripts](#scripts)
-- [Copilot features (optional)](#copilot-features-optional)
-- [CI/CD](#cicd)
-- [Security](#security)
-- [Changelog & releases](#changelog--releases)
-- [Contributing](#contributing)
-- [Roadmap](#roadmap)
-- [FAQ](#faq)
-- [License](#license)
+- [Dev Standards](#dev-standards)
+  - [Public Repo Template](#public-repo-template)
+  - [Table of Contents](#table-of-contents)
+  - [What’s inside](#whats-inside)
+  - [Scripts](#scripts)
+  - [Copilot features (optional)](#copilot-features-optional)
+  - [CI/CD](#cicd)
+  - [Security](#security)
+  - [Changelog \& releases](#changelog--releases)
+  - [Contributing](#contributing)
+  - [Roadmap](#roadmap)
+  - [FAQ](#faq)
+  - [License](#license)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ A public GitHub template repository that bakes in DevOps hygiene and optional AI
 New here? Read the detailed design/build guide: [PROJECT_GUIDE.md](PROJECT_GUIDE.md)
 
 ---
+
 ## Table of Contents
 
 - [What’s inside](#whats-inside)
 - [Quickstart](#quickstart)
 - [Scripts](#scripts)
-- [AI features (optional)](#ai-features-optional)
+- [Copilot features (optional)](#copilot-features-optional)
 - [CI/CD](#cicd)
 - [Security](#security)
 - [Changelog & releases](#changelog--releases)
@@ -35,6 +36,7 @@ New here? Read the detailed design/build guide: [PROJECT_GUIDE.md](PROJECT_GUIDE
 - [License](#license)
 
 ---
+
 ## What’s inside
 
 ```
@@ -64,8 +66,8 @@ tsconfig.json             # TS compiler config
 docs/
 	architecture.md         # Mermaid of CI → PR → changelog flow
 scripts/
-	ai/changelog_check.mjs  # PR body validator + AI suggestions
-	ai/changelog_generate.mjs# create draft notes from commits
+	automation/changelog_check.mjs  # PR body validator (suggestion hook future)
+	automation/changelog_generate.mjs# create draft notes from commits (planned)
 	metrics/log_build.mjs   # optional telemetry demo
 src/
 	index.ts                # sample module
@@ -73,6 +75,7 @@ src/
 ```
 
 ---
+
 ## Scripts
 
 - `pnpm lint` — lint placeholder (swap in ESLint later)
@@ -81,25 +84,19 @@ src/
 - `pnpm build` — compile to `dist/`
 - `pnpm verify` — run lint + typecheck + test
 
----
-## AI features (optional)
+## Copilot features (optional)
 
-Add **Settings → Secrets and variables → Actions**:
+Enable GitHub Copilot (org or user level) — no repository secret required.
 
-- `OPENAI_API_KEY` (required for AI features)
-- `OPENAI_MODEL` (optional; default gpt-4o-mini)
+Copilot-assisted flows:
 
-AI‑assisted workflows:
+- **In-editor suggestions**: accelerate implementation & tests.
+- **PR summaries (beta/feature flagged)**: generate a summary of changes; adapt into the `## Changelog` block.
+- **Release note drafting**: when creating a GitHub Release, use "Generate release notes" then refine with Copilot Chat.
+- **Changelog bullets**: ask Copilot Chat: _"Summarise the diff for PR #123 into Keep a Changelog Added/Changed/Fixed bullets"_.
 
-- **PR Changelog Guard** (`.github/workflows/pr-changelog-guard.yml`)
-	- Fails PRs missing a `## Changelog` section.
-	- Prints a suggested entry based on `CHANGELOG_GUIDE.md` if AI is enabled.
-- **AI Changelog on Merge** (`.github/workflows/ai-changelog.yml`)
-	- On push to `main|master|release/**`, scans commits since last tag and opens a PR updating `CHANGELOG.md` with draft notes.
+Planned automation (optional): a future workflow can collect commits since last tag and open a draft PR; you then use Copilot to polish wording.
 
-Humans remain reviewers. AI suggests text; you approve or edit.
-
----
 ## CI/CD
 
 - CI runs on every PR and push to `main|master`.
@@ -115,7 +112,6 @@ Humans remain reviewers. AI suggests text; you approve or edit.
 
 See the Mermaid diagram in [docs/architecture.md](docs/architecture.md).
 
----
 ## Security
 
 - Code scanning via CodeQL
@@ -127,7 +123,6 @@ See the Mermaid diagram in [docs/architecture.md](docs/architecture.md).
 - Require PR review (≥1)
 - Required checks: CI, PR changelog guard
 
----
 ## Changelog & releases
 
 We follow [Keep a Changelog](https://keepachangelog.com/) + SemVer.
@@ -136,7 +131,6 @@ We follow [Keep a Changelog](https://keepachangelog.com/) + SemVer.
 - After merges to main, the AI workflow drafts notes and opens a PR to update `CHANGELOG.md`.
 - Tag releases manually at first (`v0.1.0`). Later, consider Changesets or semantic‑release for automated versioning.
 
----
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md). Highlights:
@@ -148,7 +142,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md). Highlights:
 
 Code of Conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 
----
 ## Roadmap
 
 - **Phase 1:** Public template MVP (CI, security, PR guard, AI release notes)
@@ -158,14 +151,13 @@ Code of Conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 
 Track enhancements in Issues → Milestones.
 
----
 ## FAQ
 
 **Do I have to use pnpm?**  
 Nope. Swap to npm/yarn, and update `ci.yml` accordingly.
 
-**What happens if I don’t set an OpenAI key?**  
-AI steps are skipped; CI still runs normally.
+**What if Copilot is disabled?**  
+All automation still works; you just lose AI drafting aids (write changelog/release notes manually).
 
 **Why Apache‑2.0?**  
 It’s permissive with an explicit patent grant — friendly for employers. Switch to MIT if you prefer.
@@ -173,7 +165,6 @@ It’s permissive with an explicit patent grant — friendly for employers. Swit
 **Can I use this for non‑Node projects?**  
 Yes. Replace the scripts and TypeScript config; keep the workflows and docs.
 
----
 ## License
 
 Copyright © 2025 Andrew Wilks.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ New here? Read the detailed design/build guide: [PROJECT_GUIDE.md](PROJECT_GUIDE
   - [Copilot features (optional)](#copilot-features-optional)
   - [CI/CD](#cicd)
   - [Security](#security)
-  - [Changelog & releases](#changelog--releases)
+  - [Changelog \& releases](#changelog--releases)
   - [Contributing](#contributing)
   - [Roadmap](#roadmap)
   - [FAQ](#faq)
@@ -41,16 +41,16 @@ New here? Read the detailed design/build guide: [PROJECT_GUIDE.md](PROJECT_GUIDE
 
 ## What’s inside
 
-```
+```text
 .github/
-	ISSUE_TEMPLATE/         # bug/feature forms
-	PULL_REQUEST_TEMPLATE.md
-	workflows/
-		ci.yml                # lint/type/test/build
-		pr-changelog-guard.yml# enforce PR changelog block + AI suggest
-		ai-changelog.yml      # draft release notes PR on merge
-		codeql.yml            # security scanning
-		dependabot.yml        # weekly updates
+  ISSUE_TEMPLATE/         # bug/feature forms
+  PULL_REQUEST_TEMPLATE.md
+  workflows/
+    ci.yml                # lint/type/test/build
+    pr-changelog-guard.yml# enforce PR changelog block + AI suggest
+    ai-changelog.yml      # draft release notes PR on merge
+    codeql.yml            # security scanning
+    dependabot.yml        # weekly updates
 .commitlintrc.cjs         # Conventional Commits
 .editorconfig             # consistent whitespace/newlines
 .gitattributes            # LF endings
@@ -66,14 +66,14 @@ CHANGELOG_GUIDE.md        # how to write entries
 package.json              # scripts + dev deps
 tsconfig.json             # TS compiler config
 docs/
-	architecture.md         # Mermaid of CI → PR → changelog flow
+  architecture.md         # Mermaid of CI → PR → changelog flow
 scripts/
-	automation/changelog_check.mjs  # PR body validator (suggestion hook future)
-	automation/changelog_generate.mjs# create draft notes from commits (planned)
-	metrics/log_build.mjs   # optional telemetry demo
+  automation/changelog_check.mjs    # PR body validator (suggestion hook future)
+  automation/changelog_generate.mjs # create draft notes from commits (planned)
+  metrics/log_build.mjs   # optional telemetry demo
 src/
-	index.ts                # sample module
-	index.test.ts           # placeholder test
+  index.ts                # sample module
+  index.test.ts           # placeholder test
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ New here? Read the detailed design/build guide: [PROJECT_GUIDE.md](PROJECT_GUIDE
   - [Copilot features (optional)](#copilot-features-optional)
   - [CI/CD](#cicd)
   - [Security](#security)
-  - [Changelog \& releases](#changelog--releases)
+  - [Changelog & releases](#changelog--releases)
   - [Contributing](#contributing)
   - [Roadmap](#roadmap)
   - [FAQ](#faq)

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ See the Mermaid diagram in [docs/architecture.md](docs/architecture.md).
 We follow [Keep a Changelog](https://keepachangelog.com/) + SemVer.
 
 - Write PRs with a `## Changelog` section (example entries in [CHANGELOG_GUIDE.md](CHANGELOG_GUIDE.md)).
-- After merges to main, the AI workflow drafts notes and opens a PR to update `CHANGELOG.md`.
+- After merges to main, the Copilot-assisted workflow drafts notes and opens a PR to update `CHANGELOG.md`.
 - Tag releases manually at first (`v0.1.0`). Later, consider Changesets or semantic‑release for automated versioning.
 
 ## Contributing


### PR DESCRIPTION
## Changelog
- Changed: Replaced OpenAI-specific instructions with GitHub Copilot usage guidance
- Changed: Renamed scripts/ai → scripts/automation (placeholder directory for future workflow helpers)
- Updated: PROJECT_GUIDE.md and README.md to reflect Copilot-driven workflow and removal of OPENAI_* secrets
- Cleaned: Removed obsolete .gitkeep

## Context
This aligns the template with an “all GitHub” approach, removing the need for external LLM API keys. Future automation (draft changelog, suggestion hooks) will leverage Copilot Chat or native GitHub features rather than custom API calls.

## Follow-ups (tracked in issues)
- Add optional changelog-draft workflow scaffold
- Introduce script stubs in automation for future commit parsing
- Update any open issues still referencing scripts/ai

## Verification
- Docs render cleanly (headings, TOC anchors, fenced blocks)
- Directory rename reflected in both guide and README
- No remaining OPENAI_* references