### PR TITLE
docs: add base contributor, conduct, and security docs + README quickstart

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,78 @@
+# Code of Conduct
+
+This project follows the Contributor Covenant, version 2.1.
+
+# Our Pledge
+
+We as members, contributors, and maintainers pledge to make participation in this
+project and our community a harassment‑free experience for everyone, regardless of
+age, body size, visible or invisible disability, ethnicity, sex characteristics,
+gender identity and expression, level of experience, education, socio‑economic status,
+nationality, personal appearance, race, caste, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Showing empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experience
+- Giving and gracefully accepting constructive feedback
+- Focusing on what is best for the community
+- Demonstrating responsibility and professionalism
+
+Examples of unacceptable behavior include:
+
+- Harassment, trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information (doxing) without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable
+behavior and will take appropriate and fair corrective action in response to any behavior
+that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and also applies when an individual is
+officially representing the project in public spaces (online or offline).
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported
+confidentially as described in [SECURITY.md](SECURITY.md). If your concern is not a security
+issue, you may also email the maintainers (replace the placeholder below):
+
+<security-contact@example.com>
+
+Please include:
+
+1. Your contact information
+2. Names (real, username, or pseudonym) of any individuals involved
+3. If possible, URLs or screenshots of the behavior
+4. Any additional context
+
+All complaints will be reviewed and investigated promptly and fairly. The project team will
+respect the privacy and security of the reporter.
+
+## Enforcement Guidelines
+
+Maintainers will follow these Community Impact Guidelines in determining the consequences for
+any action they deem in violation of this Code of Conduct:
+
+1. Correction – GitHub issue or private communication with clarifications.
+2. Warning – Written warning with consequences of continued behavior.
+3. Temporary Ban – Temporary removal from interactions and/or org spaces.
+4. Permanent Ban – Permanent removal from community spaces within the project.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+For answers to common questions about this code of conduct, see the FAQ at
+[Contributor Covenant FAQ](https://www.contributor-covenant.org/faq). Translations are available at
+[Contributor Covenant Translations](https://www.contributor-covenant.org/translations).
+
+Related docs: [CONTRIBUTING.md](CONTRIBUTING.md) • [SECURITY.md](SECURITY.md)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -45,7 +45,7 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 confidentially as described in [SECURITY.md](SECURITY.md). If your concern is not a security
 issue, you may also email the maintainers (replace the placeholder below):
 
-<security-contact@example.com>
+<me@andrewwilks.au>
 
 Please include:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,7 @@ Participation is governed by the [Code of Conduct](CODE_OF_CONDUCT.md). Behavior
 Do not file public issues for vulnerabilities. Follow the private reporting process in [SECURITY.md](SECURITY.md).
 
 ## Getting Help
+
 Open a discussion or issue for architecture questions or improvement ideas. For commit style help, see the VS Code extensions below.
 
 ## Recommended VS Code Extensions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,38 +1,107 @@
 # Contributing
 
-Thanks for helping improve this template. A few notes to get started.
+Thanks for helping improve this template. This document covers local setup, workflow, commit conventions, and how to get help.
 
-## Setup
+Related docs: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) • [SECURITY.md](SECURITY.md) • [README.md](README.md)
 
-1. Install dependencies and enable Husky hooks:
+## Quick Start
 
 ```pwsh
-pnpm install
+pnpm install     # install deps + set up Husky hooks
+pnpm verify      # lint + typecheck + build + test
+pnpm test        # run placeholder tests
+pnpm build       # compile TypeScript to dist/
 ```
 
-2. Recommended VS Code extensions (you'll be prompted when opening the workspace):
+Edit `src/index.ts`, re-run `pnpm build`, then execute:
 
-- `niieani.vscode-commitlint` — live commitlint validation
-- `vivaxy.vscode-conventional-commit` — commit message templates and UI
+```pwsh
+node dist/index.js
+```
 
-## Commit messages
+## Development Workflow
 
-We use Conventional Commits. Commit messages are validated by `commitlint` on every commit via Husky. If your commit is blocked, follow the guidance printed in the commit hook output or use the recommended VS Code extensions to author messages.
+1. Branch from `main`: `git switch -c feat/short-description`
+2. Make focused commits (see Conventional Commits below).
+3. Keep PRs small (prefer < ~400 line diffs excluding generated files).
+4. Write or update tests alongside code changes.
+5. Add a `## Changelog` section to your PR description following [CHANGELOG_GUIDE.md](CHANGELOG_GUIDE.md).
+6. Ensure `pnpm verify` passes locally before pushing.
 
-Need the full background and rationale? See the detailed case study: [`docs/case-study/commitlint-case-study.md`](docs/case-study/commitlint-case-study.md).
+## Tooling & Scripts
 
-Local checks:
+See `package.json` for full list. Common scripts:
 
-- Check commits in your branch against `origin/main`:
+- `pnpm lint` – placeholder lint (swap in ESLint later)
+- `pnpm typecheck` – TypeScript project validation
+- `pnpm test` – runs the simple assertion test harness
+- `pnpm build` – emits JS to `dist/`
+- `pnpm verify` – run the full local CI pipeline
+- `pnpm spell` – spell check markdown + src
+
+## Commit Messages (Conventional Commits)
+
+Commit messages are validated by `commitlint` (Husky hook). If blocked, adjust the header line.
+
+Format:
+
+```text
+<type>[optional scope]: <description>
+```
+
+Common types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`, `perf`, `style`.
+
+Examples:
+
+- feat(api): add CSV import for CommSec statements
+- fix(auth): handle expired tokens in refresh flow
+- docs: update README with contributing guidelines
+
+Need deeper rationale? Case study: [`docs/case-study/commitlint-case-study.md`](docs/case-study/commitlint-case-study.md)
+
+### Local Commit Checks
+
+Check commits in your branch against `origin/main`:
 
 ```pwsh
 pnpm commitlint
 ```
 
-- Validate a message file manually:
+Validate a message file manually:
 
 ```pwsh
 pnpm commitlint:msg .git/COMMIT_EDITMSG
 ```
 
-If you need to bypass the hook for a particular commit (discouraged), you can use `git commit --no-verify`.
+Bypass (discouraged): `git commit --no-verify`
+
+## Pull Requests
+
+Include in the PR description:
+
+- Purpose / context
+- `## Changelog` section (Added / Changed / Fixed etc.)
+- Screenshots for UI changes (if applicable)
+- Follow-up tasks (if any)
+
+CI must be green before review merge.
+
+## Code of Conduct
+
+Participation is governed by the [Code of Conduct](CODE_OF_CONDUCT.md). Behaviors that violate it may be reported per [SECURITY.md](SECURITY.md).
+
+## Security Issues
+
+Do not file public issues for vulnerabilities. Follow the private reporting process in [SECURITY.md](SECURITY.md).
+
+## Getting Help
+Open a discussion or issue for architecture questions or improvement ideas. For commit style help, see the VS Code extensions below.
+
+## Recommended VS Code Extensions
+
+- `niieani.vscode-commitlint` – live commitlint validation
+- `vivaxy.vscode-conventional-commit` – commit message UI
+
+---
+
+Thank you for contributing! 🎉

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Case study and docs: see `docs/case-study/commitlint-case-study.md` for an in-de
 - [Dev Standards](#dev-standards)
   - [Public Repo Template](#public-repo-template)
   - [Table of Contents](#table-of-contents)
+  - [Quickstart](#quickstart)
   - [What’s inside](#whats-inside)
   - [Scripts](#scripts)
   - [Copilot features (optional)](#copilot-features-optional)
@@ -82,6 +83,21 @@ src/
 ```
 
 ---
+
+## Quickstart
+
+Clone (or use this as a template) then:
+
+```pwsh
+pnpm install     # install deps + setup husky hooks
+pnpm verify      # run lint + typecheck + test + build
+pnpm build       # compile TypeScript
+node dist/index.js
+```
+
+Open `src/index.ts`, make a change, re-run `pnpm build` and execute again. For commit message help run `pnpm commitlint` after a few local commits.
+
+See contribution details in [CONTRIBUTING.md](CONTRIBUTING.md). For conduct expectations read [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md). Security reporting process: [SECURITY.md](SECURITY.md).
 
 ## Scripts
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ for security updates while the template is actively maintained.
 ## Reporting a Vulnerability
 
 1. DO NOT open a public issue for a suspected vulnerability.
-2. Email the maintainers privately at: <security-contact@example.com>
+2. Email the maintainers privately at: <me@andrewwilks.au>
    (Replace with a real security contact address for your fork / deployment.)
 3. Provide a clear description: impact, affected files / functions, and steps to reproduce.
 4. (Optional) Include a minimal proof of concept (PoC). Avoid exploits that could cause data loss.
@@ -44,4 +44,5 @@ Use regular Issues / Discussions for bugs, feature requests, or usability improv
 If you require encrypted email, publish a PGP key for the security contact in your fork.
 
 ## Related Documents
+
 [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) • [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,47 @@
+# Security Policy
+
+Thank you for taking the time to responsibly disclose a vulnerability.
+
+## Supported Versions
+
+This is a template repository. All released versions (tags) and the `main` branch are supported
+for security updates while the template is actively maintained.
+
+## Reporting a Vulnerability
+
+1. DO NOT open a public issue for a suspected vulnerability.
+2. Email the maintainers privately at: <security-contact@example.com>
+   (Replace with a real security contact address for your fork / deployment.)
+3. Provide a clear description: impact, affected files / functions, and steps to reproduce.
+4. (Optional) Include a minimal proof of concept (PoC). Avoid exploits that could cause data loss.
+
+We aim to acknowledge reports within 3 business days and provide a triage decision (accepted / needs more info / not a vulnerability).
+
+If you have not received a reply within 7 days, feel free to send a polite follow‑up.
+
+### Vulnerability Handling Process
+
+1. Report received and acknowledged.
+2. Triage and reproduce.
+3. Determine severity (CVSS-style qualitative: Low / Moderate / High / Critical).
+4. Prepare fix + tests.
+5. Coordinate disclosure (optional: credit the reporter if desired and consented).
+6. Release patch version + update CHANGELOG.
+7. Public advisory (GitHub Security Advisory or release notes).
+
+## Guidelines for Reporters
+
+- Act in good faith and avoid privacy violations.
+- Do not access, modify, or delete data you do not own.
+- Give us reasonable time to patch before any public disclosure.
+
+## Non-Security Issues
+
+Use regular Issues / Discussions for bugs, feature requests, or usability improvements.
+
+## Encryption (Optional)
+
+If you require encrypted email, publish a PGP key for the security contact in your fork.
+
+## Related Documents
+[CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) • [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
## Summary
Introduces the initial contributor-facing documentation set and improves onboarding speed with a Quickstart section.

## Changes
Added:
- CODE_OF_CONDUCT.md (Contributor Covenant v2.1 adaptation)
- SECURITY.md (reporting process, lifecycle, guidelines)

Updated:
- README.md: added Quickstart, updated TOC, cross-links to new docs
- CONTRIBUTING.md: expanded with workflow, scripts, PR expectations, commit guidance, help channels
- Replaced placeholder security contact email with: me@andrewwilks.au

## Rationale
These docs complete the base hygiene for a public template:
- Clear contributor workflow reduces PR friction
- Security disclosure channel formalized
- Code of Conduct establishes behavioral baseline
- Quickstart accelerates first successful local run

## Changelog
### Added
- Code of Conduct and Security Policy documents

### Changed
- Expanded contributing guidance
- README now includes Quickstart and doc cross-links

## Security
Adds explicit private reporting instructions; no runtime code changes.

## Documentation Cross‑links
- README ↔ CONTRIBUTING / CODE_OF_CONDUCT / SECURITY
- CONTRIBUTING links to CODE_OF_CONDUCT + SECURITY
- CODE_OF_CONDUCT + SECURITY reference each other and CONTRIBUTING

## Diff Stats
```
4 files changed, 226 insertions(+), 14 deletions(-)
A  CODE_OF_CONDUCT.md
A  SECURITY.md
M  CONTRIBUTING.md
M  README.md
```

## Follow Ups (Optional)
- Add markdown lint workflow if desired
- Replace placeholder sections with org-specific governance (if templating)
- Consider adding CHANGELOG scaffolding automation later

## Checklist
- [x] Conventional Commit(s)
- [x] Docs build locally (plain markdown)
- [x] Security contact updated
- [x] Cross-links verified

Fixes #3