### PR TITLE
docs(changelog): add Keep a Changelog base and contributor guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
+## [0.1.0] - 2025-10-09
+
+### Added <!-- release-0.1.0-added -->
+
+- Initial public template: CI (pnpm Node 20), CodeQL, Dependabot, contributor docs, licensing (Apache-2.0), security policy.
+
+### Security <!-- release-0.1.0-security -->
+
+- Baseline CodeQL scanning and dependency update automation.
+
+---
+
+## Formatting Conventions
+
+Each section lists bullet points starting with an imperative short phrase; avoid trailing punctuation. Group multiple related changes into a single bullet when concise.
+
+## Linking
+
+Release tag comparison links are declared at the bottom. Keep `[Unreleased]` pointing to a diff between the latest tag and `HEAD`.
+
+## Attribution
+
+Optionally credit significant contributors in a bullet using `(thanks @username)`.
+
+---
+
+[Unreleased]: https://github.com/AndrewWilks/repo-template-public/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/AndrewWilks/repo-template-public/releases/tag/v0.1.0

--- a/CHANGELOG_GUIDE.md
+++ b/CHANGELOG_GUIDE.md
@@ -1,0 +1,89 @@
+# Changelog Guide
+
+This guide explains how to write and curate entries in `CHANGELOG.md` using the **Keep a Changelog** categories and **SemVer** principles.
+
+## Philosophy
+
+The changelog is for humans first: it should communicate what changed, why it matters (briefly), and any required user action.
+
+## Categories
+
+Use only the standard headings (exact capitalization) in this order:
+
+```text
+### Added      # new features
+### Changed    # existing behavior updates (non‑breaking)
+### Deprecated # discouraged features, not yet removed
+### Removed    # permanently removed features (breaking)
+### Fixed      # bug fixes
+### Security   # vulnerabilities or hardening
+```
+
+If a section has no entries for a release, omit it in that release block (keep it in Unreleased as scaffold).
+
+## Mapping Commit Types → Categories
+
+| Commit Type (Conventional) | Typical Changelog Section | Notes |
+|----------------------------|---------------------------|-------|
+| feat                       | Added / Changed           | Added if new surface; Changed if enhancement to existing |
+| fix                        | Fixed                     | Security if vulnerability |
+| perf                       | Changed                   | If user‑visible; otherwise may omit |
+| refactor                   | (Usually omit) / Changed  | Include only if user behavior or API affected |
+| docs                       | (Omit)                    | Unless docs shipped as part of feature |
+| chore / ci / build         | (Omit)                    | Unless impacts consumers (e.g., drop Node version) |
+| deps (chore/deps)          | Changed / Security        | Security if addressing a CVE |
+| revert                     | Changed / Removed         | Describe net effect |
+
+## Writing Rules
+
+1. Start bullets with a verb in present tense: "Add", "Change", "Fix".
+2. No trailing period unless multiple sentences are needed (rare).
+3. Avoid internal ticket numbers; link PRs or issues inline: `(#123)`.
+4. Breaking changes: add a bold **BREAKING** marker or use `Changed`/`Removed` and append an action note:
+   - Example: `Remove legacy configuration flag '--foo' (BREAKING: use '--bar' instead).`
+5. Security advisories: include CVE or GHSA identifier if public.
+6. Group related minor fixes: `Fix several typos in README and CONTRIBUTING`.
+7. Keep Unreleased tidy—squash noise before tagging a release.
+
+## Release Flow
+
+1. PRs include a `## Changelog` block with proposed bullets.
+2. On merge, bullets accumulate under `## [Unreleased]`.
+3. Before tagging:
+   - Curate wording for consistency.
+   - Remove empty category headings in the upcoming release block.
+   - Update comparison links at bottom.
+4. Tag `vX.Y.Z` and update `[Unreleased]` link to point from new tag to `HEAD`.
+
+## Examples
+
+```markdown
+## [1.4.0] - 2025-11-03
+### Added
+- Add CSV importer for broker statements (#142)
+
+### Changed
+- Change default log level to 'info' (was 'warn') (#155)
+
+### Fixed
+- Fix race condition in cache warm logic (#151)
+
+### Security
+- Bump jsonwebtoken to 9.0.2 (GHSA-xxxx) (#160)
+```
+
+## Common Pitfalls
+
+- Over‑verbosity: collapse internal refactors that have no external impact.
+- Mixing tense: keep present tense for uniformity.
+- Duplicating commit subjects verbatim—rewrite for reader clarity.
+
+## Tooling Ideas (Future)
+
+- PR bot that validates `## Changelog` presence.
+- Automatic grouping + AI summarisation for large diff sets.
+- Conventional Commits → provisional changelog generation script.
+
+---
+
+See current history in [`CHANGELOG.md`](CHANGELOG.md).

--- a/CHANGELOG_GUIDE.md
+++ b/CHANGELOG_GUIDE.md
@@ -23,16 +23,16 @@ If a section has no entries for a release, omit it in that release block (keep i
 
 ## Mapping Commit Types → Categories
 
-| Commit Type (Conventional) | Typical Changelog Section | Notes |
-|----------------------------|---------------------------|-------|
+| Commit Type (Conventional) | Typical Changelog Section | Notes                                                    |
+| -------------------------- | ------------------------- | -------------------------------------------------------- |
 | feat                       | Added / Changed           | Added if new surface; Changed if enhancement to existing |
-| fix                        | Fixed                     | Security if vulnerability |
-| perf                       | Changed                   | If user‑visible; otherwise may omit |
-| refactor                   | (Usually omit) / Changed  | Include only if user behavior or API affected |
-| docs                       | (Omit)                    | Unless docs shipped as part of feature |
-| chore / ci / build         | (Omit)                    | Unless impacts consumers (e.g., drop Node version) |
-| deps (chore/deps)          | Changed / Security        | Security if addressing a CVE |
-| revert                     | Changed / Removed         | Describe net effect |
+| fix                        | Fixed                     | Security if vulnerability                                |
+| perf                       | Changed                   | If user‑visible; otherwise may omit                      |
+| refactor                   | (Usually omit) / Changed  | Include only if user behavior or API affected            |
+| docs                       | (Omit)                    | Unless docs shipped as part of feature                   |
+| chore / ci / build         | (Omit)                    | Unless impacts consumers (e.g., drop Node version)       |
+| deps (chore/deps)          | Changed / Security        | Security if addressing a CVE                             |
+| revert                     | Changed / Removed         | Describe net effect                                      |
 
 ## Writing Rules
 
@@ -59,16 +59,21 @@ If a section has no entries for a release, omit it in that release block (keep i
 
 ```markdown
 ## [1.4.0] - 2025-11-03
+
 ### Added
+
 - Add CSV importer for broker statements (#142)
 
 ### Changed
+
 - Change default log level to 'info' (was 'warn') (#155)
 
 ### Fixed
+
 - Fix race condition in cache warm logic (#151)
 
 ### Security
+
 - Bump jsonwebtoken to 9.0.2 (GHSA-xxxx) (#160)
 ```
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Case study: A short write-up describing the commitlint design and trade-offs is 
 
 ## Changelog & releases
 
-We follow [Keep a Changelog](https://keepachangelog.com/) + SemVer.
+We follow [Keep a Changelog](https://keepachangelog.com/) + SemVer. See [CHANGELOG.md](CHANGELOG.md) for history and [CHANGELOG_GUIDE.md](CHANGELOG_GUIDE.md) for how to write entries.
 
 - Write PRs with a `## Changelog` section (example entries in [CHANGELOG_GUIDE.md](CHANGELOG_GUIDE.md)).
 - After merges to main, the Copilot-assisted workflow drafts notes and opens a PR to update `CHANGELOG.md`.


### PR DESCRIPTION
## Summary
Adds a Keep a Changelog–compliant changelog and a contributor guide explaining how to write entries, aligned with SemVer. Updates README to link to both.

## Changes
- CHANGELOG.md — Scaffold with Unreleased section and example 0.1.0 entry
- CHANGELOG_GUIDE.md — How-to guide (categories, mapping from Conventional Commits, examples, release flow)
- README.md — Link to CHANGELOG.md and CHANGELOG_GUIDE.md in “Changelog & releases”

## Why
- Standardizes release notes across contributions
- Guides contributors to include consistent, useful changelog bullets in PRs
- Prepares for future automation to draft release notes

## Acceptance Criteria
- [x] Files exist with category templates and examples (CHANGELOG.md, CHANGELOG_GUIDE.md)
- [x] README links to both files

## Notes
- Follows Keep a Changelog 1.1.0 and SemVer 2.0.0.
- Markdown linting passes (headings, spacing, fenced languages).

## Changelog
### Added
- Add CHANGELOG.md scaffold and CHANGELOG_GUIDE.md with writing rules and examples
- Link both files from README