### PR TITLE
docs(pr): add PR template and form with mandatory changelog and CI checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+# Pull Request
+
+<!--
+Thank you for your contribution!
+
+Please fill out the sections below. Submissions without a changelog will be asked to update before review.
+-->
+## Summary
+
+Describe what this PR changes and why.
+
+## Changelog (required)
+
+Follow Keep a Changelog categories. See the guide: [CHANGELOG_GUIDE.md](../CHANGELOG_GUIDE.md)
+
+Copy one or more categories and add bullets; delete empty ones before submitting:
+
+### Added
+
+
+### Changed
+
+
+### Deprecated
+
+
+### Removed
+
+
+### Fixed
+
+
+### Security
+
+
+## Checklist
+
+
+## Related
+
+Link related Issues/PRs, e.g. closes #123.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,7 @@ Thank you for your contribution!
 
 Please fill out the sections below. Submissions without a changelog will be asked to update before review.
 -->
+
 ## Summary
 
 Describe what this PR changes and why.
@@ -17,24 +18,17 @@ Copy one or more categories and add bullets; delete empty ones before submitting
 
 ### Added
 
-
 ### Changed
-
 
 ### Deprecated
 
-
 ### Removed
-
 
 ### Fixed
 
-
 ### Security
 
-
 ## Checklist
-
 
 ## Related
 

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.yml
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.yml
@@ -3,6 +3,9 @@ description: Provide a clear summary, required changelog, and confirmations
 title: "<type>(<scope>): <short summary>"
 labels:
   - documentation
+  - changelog
+assignees:
+  - AndrewWilks
 body:
   - type: markdown
     attributes:
@@ -43,7 +46,7 @@ body:
         - 
 
         ### Security
-        - 
+        -
     validations:
       required: true
 
@@ -55,6 +58,8 @@ body:
         - label: I used a Conventional Commit title
           required: true
         - label: I updated the Changelog block above
+          required: true
+        - label: CI is green for this PR
           required: true
         - label: Tests added/updated (if applicable)
           required: false

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.yml
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.yml
@@ -1,0 +1,76 @@
+name: Pull request
+description: Provide a clear summary, required changelog, and confirmations
+title: "<type>(<scope>): <short summary>"
+labels:
+  - documentation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for contributing! Please complete the fields below.
+        - Use Conventional Commits in the PR title (e.g., `feat(api): add X`).
+        - Follow Keep a Changelog categories for the changelog.
+        - See the guide: [CHANGELOG_GUIDE.md](../../CHANGELOG_GUIDE.md)
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What does this change do and why?
+      placeholder: Short description of the change and context.
+    validations:
+      required: true
+
+  - type: textarea
+    id: changelog
+    attributes:
+      label: Changelog (required)
+      description: Use Keep a Changelog categories. Remove empty sections.
+      value: |
+        ### Added
+        - 
+
+        ### Changed
+        - 
+
+        ### Deprecated
+        - 
+
+        ### Removed
+        - 
+
+        ### Fixed
+        - 
+
+        ### Security
+        - 
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I used a Conventional Commit title
+          required: true
+        - label: I updated the Changelog block above
+          required: true
+        - label: Tests added/updated (if applicable)
+          required: false
+        - label: Docs updated (if applicable)
+          required: false
+
+  - type: input
+    id: related
+    attributes:
+      label: Related issues/PRs
+      description: Link relevant Issues/PRs (e.g., closes #123)
+      placeholder: closes #123, relates to #456
+
+  - type: textarea
+    id: breaking
+    attributes:
+      label: Breaking changes
+      description: Describe any breaking changes and required migration steps
+      placeholder: BREAKING CHANGE — describe impact and migration

--- a/.github/PULL_REQUEST_TEMPLATE/small_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/small_fix.md
@@ -1,0 +1,14 @@
+# Small fix
+
+Short description of the change.
+
+## Changelog (required)
+
+### Fixed
+
+-
+
+## Checklist
+
+- [ ] CI is green
+- [ ] I updated the Changelog block above


### PR DESCRIPTION
## Summary
Add a default Pull Request markdown template and a GitHub PR form that require a `## Changelog` block. The form provides structured fields to help contributors provide a summary, a Keep‑a‑Changelog formatted changelog, a checklist (including CI required), related issues, and breaking change notes. A small `small_fix.md` minimal template was added for quick fixes.

## Changes
- PULL_REQUEST_TEMPLATE.md — Freeform PR template enforcing `## Changelog` block and checklist.
- pull_request_template.yml — GitHub PR form (UI) with required changelog, checklist, labels, and assignee defaults.
- small_fix.md — Minimal PR template for small/fix-only changes.

## Why
- Improves release notes quality by making changelog entries mandatory.
- Helps contributors structure PRs and reduces back-and-forth during review.
- Makes CI and changelog checks explicit before merge.

## Acceptance Criteria
- [x] PR template loads by default when opening a PR
- [x] PR form requires a changelog block and includes CI checklist item
- [x] Minimal small-fix template available for faster minor fixes

## Notes / Next steps
- The PR form auto-assigns `AndrewWilks` and applies `documentation` + `changelog` labels by default; edit pull_request_template.yml to change.
- I can open the PR for you, add labels, or adjust wording if you want — tell me which.

Fixes #9