### PR TITLE
docs: add architecture diagram and align PROJECT_GUIDE

### DIFF
--- a/PROJECT_GUIDE.md
+++ b/PROJECT_GUIDE.md
@@ -34,7 +34,7 @@ repo-template-public/
 │  └─ workflows/
 │     ├─ ci.yml                   # build/lint/type/test
 │     ├─ pr-changelog-guard.yml   # validate PR body and suggest text (AI)
-│     ├─ ai-changelog.yml         # on merge: draft CHANGELOG and open PR
+│     ├─ ai-changelog.yml         # (optional/planned) on merge: draft CHANGELOG and open PR
 │     ├─ codeql.yml               # security scanning
 │     └─ dependabot.yml           # weekly updates
 ├─ .commitlintrc.cjs
@@ -55,13 +55,13 @@ repo-template-public/
 │  ├─ architecture.md             # Mermaid diagram of CI/PR/changelog flow
 │  └─ api/auto.md                 # optional AI‑generated docs
 ├─ scripts/
+│  ├─ changelog-detect.mjs        # PR body detection utility (current)
 │  ├─ automation/
-│  │  ├─ changelog_check.mjs      # PR body validator + (future) suggestion hook
-│  │  └─ changelog_generate.mjs   # draft release notes from commits (planned)
+│  │  └─ .gitkeep                 # placeholder for future automation scripts
 │  ├─ metrics/
-│  │  └─ log_build.mjs            # optional telemetry demo
+│  │  └─ .gitkeep                 # placeholder for optional telemetry demo
 │  └─ release/
-│     └─ prepare_release.mjs      # optional version hook
+│     └─ .gitkeep                 # placeholder for release helpers
 └─ src/
     ├─ index.ts
     └─ index.test.ts               # placeholder; swap for Vitest later

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,54 @@
+# Architecture: CI and PR changelog enforcement
+
+This document describes the automated flow for Pull Requests, changelog enforcement, CI, and the AI-assisted changelog PR that updates `CHANGELOG.md`.
+
+## Diagram
+
+```mermaid
+flowchart TD
+  subgraph PR_Flow [Pull Request Flow]
+    PR["PR opened / edited / synchronized"]
+    PRF["PR form (/.github/PULL_REQUEST_TEMPLATE/pull_request_template.yml)"]
+    PR --> PRF
+    PR --> Guard["pr-changelog-guard.yml\n(.github/workflows/pr-changelog-guard.yml)"]
+    Guard -->|missing changelog| Comment["Posts scaffold comment\nAdds label: needs-changelog"]
+    Guard -->|has changelog| Labels["Category labels\nfeature / fix / security"]
+    Comment -->|edit PR body or comment '/recheck-changelog'| Recheck["pr-changelog-recheck.yml\n(.github/workflows/pr-changelog-recheck.yml)"]
+    Recheck --> Guard
+    Guard --> CI["CI pipeline (build & tests)\n(.github/workflows/ci.yml)"]
+  end
+
+  subgraph Merge_Flow [Post-merge / Changelog automation]
+    CI -->|on success & merge| Merge["Merge to main"]
+    Merge --> AI["AI changelog workflow\n(.github/workflows/ai-changelog.yml)"]
+    AI --> CH["Drafts / updates CHANGELOG.md via PR"]
+  end
+
+  PRF -.->|helps authors fill| Guard
+  PR -->|labels present matching bypass| Bypass["Bypass labels / author allowlist\n(BYPASS_LABELS / AUTHOR_ALLOWLIST)"]
+  Bypass -.-> Guard
+```
+
+## Components referenced
+
+- `.github/PULL_REQUEST_TEMPLATE/pull_request_template.yml` — structured PR form presented to contributors.
+- `.github/PULL_REQUEST_TEMPLATE.md` — human-readable PR template that encourages a `## Changelog` section.
+- `.github/workflows/pr-changelog-guard.yml` — checks PR bodies for a completed `## Changelog` section, posts a scaffold comment and adds `needs-changelog` when missing, or applies category labels when present.
+- `.github/workflows/pr-changelog-recheck.yml` — listens for `/recheck-changelog` comments and re-runs the guard logic.
+- `.github/workflows/ci.yml` — main CI pipeline (pnpm install, build, test).
+- `.github/workflows/ai-changelog.yml` — (optional) workflow that runs after merge to draft or open a PR updating `CHANGELOG.md`.
+- `CHANGELOG_GUIDE.md` — writing guidance and examples for contributors.
+
+## Notes and operational details
+
+- Bypass rules: The guard supports environment configurable bypass labels (`BYPASS_LABELS`, default: `chore,dependabot,no-changelog-needed`) and an `AUTHOR_ALLOWLIST`. When bypass conditions apply the guard won't fail and will remove an existing `needs-changelog` label.
+- UX: When the guard detects a missing changelog it posts a helpful scaffold comment and adds the `needs-changelog` label instead of silently failing. Authors can edit the PR body or comment `/recheck-changelog` to re-run the check.
+- Keep this diagram in sync with the actual workflow filenames if they are renamed. The mermaid diagram is intentionally simple — refer to the workflow yaml files for exact triggers and permissions.
+
+## How to update
+
+Edit this file and update the diagram and component list when workflows or filenames change. Prefer small, incremental updates and open a PR that includes an entry in `CHANGELOG.md` if behavior changes.
+
+---
+
+Generated on branch `docs/architecture`.


### PR DESCRIPTION
Title: docs: add architecture diagram and align PROJECT_GUIDE

Summary

Adds an architecture document describing the automated flow for Pull Requests, changelog enforcement, CI, and the optional AI-assisted changelog PR. Also updates `PROJECT_GUIDE.md` to reflect the repository's current workflows and scripts.

Why

- Makes the CI → PR guard → recheck → merge → AI changelog flow explicit for maintainers and contributors.
- Keeps the contributor guide accurate so new projects using this template have correct references.

What changed

- Added: `docs/architecture.md` — Mermaid diagram and explanatory notes describing the flow and components.
- Updated: `PROJECT_GUIDE.md` — mark `ai-changelog.yml` as planned/optional and reflect actual `scripts/` contents (`scripts/changelog-detect.mjs` and placeholders).

Files touched

- docs/architecture.md (new)
- PROJECT_GUIDE.md (updated)

How I validated

- Ensured the Mermaid doc renders as markdown and fixed markdownlint heading issues.
- Confirmed workflow filenames under `.github/workflows/` (ci.yml, pr-changelog-guard.yml, pr-changelog-recheck.yml, pr-changelog-tests.yml, codeql.yml, commitlint.yml).
- Confirmed `scripts/` contains `changelog-detect.mjs` and placeholder `.gitkeep` files in subfolders.

Reviewer notes / Testing steps

1. Preview `docs/architecture.md` on GitHub to verify the Mermaid diagram renders correctly.
2. Confirm the high-level flow matches the workflows in `.github/workflows/`.
3. If you want, I can add a small PR note or image export of the Mermaid for easier reviewing.

Related

- Branch: `docs/architecture`

Checklist

- [x] I have added/updated documentation where needed
- [x] The PR body contains a `## Changelog` section (required by PR template)
- [x] CI checks are expected to pass (CI will run on PR)

## Changelog

### Added
- `docs/architecture.md` — architecture diagram showing PR flow and automation.

### Changed
- `PROJECT_GUIDE.md` — updated scripts/workflows list to reflect current repo state; marked `ai-changelog.yml` as planned/optional.

