### PR TITLE
docs: fill README TODOs and add architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,18 @@ Case study and docs: see `docs/case-study/commitlint-case-study.md` for an in-de
 ## What’s inside
 
 ```text
- TODO: add tree output
+repo-template-public/
+├─ .github/
+│  ├─ workflows/        # CI and automation
+│  └─ js_repo_tools/     # workflow helper scripts
+├─ configs/             # configuration fragments
+├─ docs/
+│  └─ repo/             # relocated community docs (CONTRIBUTING, CHANGELOG)
+├─ scripts/             # optional helper scripts / proxies
+├─ src/                 # TypeScript source
+├─ test/                # unit tests (Vitest)
+├─ package.json
+└─ README.md
 ```
 
 ---

--- a/docs/repo/architecture.md
+++ b/docs/repo/architecture.md
@@ -5,12 +5,26 @@ This document describes the automated flow for Pull Requests, changelog enforcem
 ## Diagram
 
 ```mermaid
-TODO: Add the mermaid diagram from the original file here
+flowchart LR
+  A[PR opened/edited] --> B[PR changelog guard workflow]
+  B -->|missing| C[Post scaffold comment + add needs-changelog label]
+  B -->|present| D[Add category labels and pass check]
+  C --> E[Author updates PR body]
+  E --> B
+  subgraph CI
+    B --> F[CI: lint → typecheck → test → build]
+  end
 ```
 
 ## Components referenced
 
-TODO: Add the components list from the original file here
+Components referenced
+
+- PR changelog guard workflow: `.github/workflows/pr-changelog-guard.yml`
+- Recheck workflow: `.github/workflows/pr-changelog-recheck.yml`
+- Guard helper scripts: `.github/js_repo_tools/pr-changelog-guard.mjs`
+- Recheck helper scripts: `.github/js_repo_tools/pr-changelog-recheck.mjs`
+- Changelog guide: `docs/repo/CHANGELOG_GUIDE.md`
 
 ## Notes and operational details
 


### PR DESCRIPTION
This PR fills a couple of small TODOs: adds a concise repo tree to the README and inserts a simple mermaid diagram + component list into docs/repo/architecture.md. Tests were run locally and pass.